### PR TITLE
Deinit overwritten KeyCallbackEntry in registerKeyInputCallback()

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -520,6 +520,7 @@ pub const KeyCallbackMachine = struct {
                     }
                 }
                 if (match) {
+                    self.key_callbacks.container.items[j].deinit();
                     self.key_callbacks.container.items[j] = inserted_entry;
                     return;
                 }


### PR DESCRIPTION
Fixes:

```
error(gpa): memory address 0x7f494e110000 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e110040 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e110080 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e1100c0 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e110100 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e110140 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e110180 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^

error(gpa): memory address 0x7f494e1101c0 leaked: 
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:458:67: 0x2c34de in ensureTotalCapacityPrecise (zigline-test)
                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
                                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:434:51: 0x2afe20 in ensureTotalCapacity (zigline-test)
            return self.ensureTotalCapacityPrecise(better_capacity);
                                                  ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:469:44: 0x2984d7 in ensureUnusedCapacity (zigline-test)
            return self.ensureTotalCapacity(self.items.len + additional_count);
                                           ^
/nix/store/5da45p00yk5wfa5lwxmqxhrzz8lbxrbc-zig-0.12.0-dev.1754+2a3226453/lib/std/array_list.zig:312:42: 0x279a69 in appendSlice (zigline-test)
            try self.ensureUnusedCapacity(items.len);
                                         ^
/home/linus/Dev/zigline/src/main.zig:408:44: 0x22e2c8 in init (zigline-test)
        self.sequence.container.appendSlice(sequence) catch unreachable;
                                           ^
/home/linus/Dev/zigline/src/main.zig:512:53: 0x22df18 in registerKeyInputCallback (zigline-test)
        const inserted_entry = KeyCallbackEntry.init(self.key_callbacks.container.allocator, sequence, c);
                                                    ^
```