### PR TITLE
Cleanup and modernize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v3
-      - name: setup zig
-        uses: goto-bus-stop/setup-zig@v2.1.1
+      - uses: actions/checkout@v5
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
       - name: Check format
         run: zig fmt --check src
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-out/
 .zig-cache/
 .vscode/
+test.hist

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .zigline,
+    .version = "0.1.0",
+    .fingerprint = 0x21cdce3e076c59ea,
+    .paths = .{
+        "LICENSE",
+        "README.md",
+        "build.zig",
+        "build.zig.zon",
+        "src/",
+    },
+}

--- a/src/sane.zig
+++ b/src/sane.zig
@@ -18,7 +18,7 @@ fn DeinitingAutoHashMap(comptime K: type, comptime V: type, comptime deinit_key:
 
         pub fn init(allocator: Allocator) Self {
             return .{
-                .container = std.AutoHashMap(K, V).init(allocator),
+                .container = .init(allocator),
             };
         }
 
@@ -42,8 +42,8 @@ fn DeinitingArrayList(comptime T: type, comptime deinit_fn: anytype) type {
         }
 
         pub fn init(allocator: Allocator) Self {
-            return Self{
-                .container = std.ArrayList(T).init(allocator),
+            return .{
+                .container = .init(allocator),
             };
         }
 
@@ -91,8 +91,8 @@ pub fn Queue(comptime T: type) type {
 
         const Self = @This();
         pub fn init(allocator: Allocator) Self {
-            return Self{
-                .container = ArrayList(T).init(allocator),
+            return .{
+                .container = .init(allocator),
             };
         }
 
@@ -142,7 +142,7 @@ pub const StringBuilder = struct {
 
     pub fn init(allocator: Allocator) Self {
         return .{
-            .buffer = ArrayList(u8).init(allocator),
+            .buffer = .init(allocator),
         };
     }
 
@@ -151,7 +151,7 @@ pub const StringBuilder = struct {
     }
 
     pub fn appendCodePoint(self: *Self, c: u32) !void {
-        var buf: [4]u8 = [_]u8{0} ** 4;
+        var buf: [4]u8 = @splat(0);
         const length = try std.unicode.utf8Encode(@intCast(c), &buf);
         try self.buffer.container.appendSlice(buf[0..length]);
     }


### PR DESCRIPTION
Use proper casing for enums, embrace type inference, decl literals. The custom containers stand out like a sore thumb, especially now that Zig has moved to unmanaged containers, but I haven't touched them yet and will try to keep the API intact as much as possible even when upgrading to 0.15.